### PR TITLE
feat: add short value references (1.9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.9.0] - 2026-07-14
+
+### Added
+- Added `$fl.value{global.path}` interpolation to every string resolved through `fl.value`, including embedded, multiple, env-aware and recursive references.
+- Kept existing behavior for values without the new marker; added `$$fl.value{...}` for literal markers and explicit errors for missing paths, invalid syntax and cycles.
+
 ## [1.8.13] - 2026-07-14
 
 ### Changed

--- a/charts/helm-apps/Chart.yaml
+++ b/charts/helm-apps/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: helm-apps
 description: A Helm applications library
 type: library
-version: 1.8.13
+version: 1.9.0
 icon: https://raw.githubusercontent.com/alvnukov/helm-apps/main/docs/assets/icon.png
 maintainers:
   - name: alvnukov

--- a/charts/helm-apps/templates/fl-functions/_value.tpl
+++ b/charts/helm-apps/templates/fl-functions/_value.tpl
@@ -5,6 +5,7 @@
   {{- $currentEnv := include "fl.currentEnv" (list $) | trim }}
   {{- $prefix := "" }}  {{- /* Optional */ -}}
   {{- $suffix := "" }}  {{- /* Optional */ -}}
+  {{- $referenceStack := list }}  {{- /* Internal */ -}}
   {{- if gt (len .) 3 }}
     {{- $optionalArgs := index . 3 }}
     {{- if hasKey $optionalArgs "prefix" }}
@@ -12,6 +13,9 @@
     {{- end }}
     {{- if hasKey $optionalArgs "suffix" }}
       {{- $suffix = $optionalArgs.suffix }}
+    {{- end }}
+    {{- if hasKey $optionalArgs "referenceStack" }}
+      {{- $referenceStack = $optionalArgs.referenceStack }}
     {{- end }}
   {{- end }}
 
@@ -24,9 +28,9 @@
     {{- else if hasKey $val "_default" }}
       {{- $currentEnvVal = index $val "_default" }}
     {{- end }}
-    {{- include "fl._renderValue" (list $ $relativeScope $currentEnvVal $prefix $suffix) }}
+    {{- include "fl._renderValue" (list $ $relativeScope $currentEnvVal $prefix $suffix $referenceStack) }}
   {{- else }}
-    {{- include "fl._renderValue" (list $ $relativeScope $val $prefix $suffix) }}
+    {{- include "fl._renderValue" (list $ $relativeScope $val $prefix $suffix $referenceStack) }}
   {{- end }}
 {{- end }}
 
@@ -36,10 +40,14 @@
   {{- $val := index . 2 }}
   {{- $prefix := index . 3 }}
   {{- $suffix := index . 4 }}
+  {{- $referenceStack := index . 5 }}
 
   {{- if and (not (kindIs "map" $val)) (not (kindIs "slice" $val)) }}
     {{- $valAsString := toString $val }}
     {{- if not (regexMatch "^<(nil|no value)>$" $valAsString) }}
+      {{- if contains "$fl.value{" $valAsString }}
+        {{- $valAsString = include "fl._expandValueReferences" (list $ $relativeScope $valAsString $referenceStack) }}
+      {{- end }}
       {{- $result := "" }}
       {{- if contains "{{" $valAsString }}
         {{- include "fl._validateTplValue" (list $ $valAsString) }}
@@ -53,6 +61,45 @@
       {{- if ne $result "" }}{{ $result }}{{ end }}
     {{- end }}
   {{- end }}
+{{- end -}}
+
+{{- define "fl._expandValueReferences" -}}
+{{- $ := index . 0 -}}
+{{- $relativeScope := index . 1 -}}
+{{- $value := toString (index . 2) -}}
+{{- $referenceStack := index . 3 -}}
+{{- $escapedOpen := printf "__HELM_APPS_ESCAPED_FL_VALUE_%s__" (sha256sum $value) -}}
+{{- $value = replace "$$fl.value{" $escapedOpen $value -}}
+{{- $pattern := "\\$fl\\.value\\{[A-Za-z0-9_-]+(\\.[A-Za-z0-9_-]+)*\\}" -}}
+{{- $references := uniq (regexFindAll $pattern $value -1) -}}
+{{- $withoutValidReferences := $value -}}
+{{- range $reference := $references -}}
+  {{- $withoutValidReferences = replace $reference "" $withoutValidReferences -}}
+{{- end -}}
+{{- if contains "$fl.value{" $withoutValidReferences -}}
+  {{- include "apps-utils.error" (list $ "E_VALUE_REF_SYNTAX" "invalid $fl.value reference syntax" "use $fl.value{global.path} with dot-separated [A-Za-z0-9_-] path segments" "docs/reference-values.md#param-value-references") -}}
+{{- end -}}
+{{- range $reference := $references -}}
+  {{- $path := trimSuffix "}" (trimPrefix "$fl.value{" $reference) -}}
+  {{- if has $path $referenceStack -}}
+    {{- include "apps-utils.error" (list $ "E_VALUE_REF_CYCLE" (printf "cyclic $fl.value reference detected: %s" (append $referenceStack $path)) "remove the reference cycle" "docs/reference-values.md#param-value-references") -}}
+  {{- end -}}
+  {{- $current := $.Values -}}
+  {{- $found := true -}}
+  {{- range $segment := splitList "." $path -}}
+    {{- if and $found (kindIs "map" $current) (hasKey $current $segment) -}}
+      {{- $current = index $current $segment -}}
+    {{- else -}}
+      {{- $found = false -}}
+    {{- end -}}
+  {{- end -}}
+  {{- if not $found -}}
+    {{- include "apps-utils.error" (list $ "E_VALUE_REF_NOT_FOUND" (printf "$fl.value reference path not found: %s" $path) "define the path under .Values or fix the reference" "docs/reference-values.md#param-value-references") -}}
+  {{- end -}}
+  {{- $resolved := include "fl.value" (list $ $relativeScope $current (dict "referenceStack" (append $referenceStack $path))) -}}
+  {{- $value = replace $reference $resolved $value -}}
+{{- end -}}
+{{- replace $escapedOpen "$fl.value{" $value -}}
 {{- end -}}
 
 {{- define "fl.currentEnv" -}}

--- a/docs/ai/helm-apps-capabilities.prompt.md
+++ b/docs/ai/helm-apps-capabilities.prompt.md
@@ -418,6 +418,7 @@ Use this file as machine-oriented context for AI prompts about helm-apps values 
 - `apps.value`
 - `fl.Result`
 - `fl._concatLists`
+- `fl._expandValueReferences`
 - `fl._getJoinedIncludesInJson`
 - `fl._recursiveMapsMerge`
 - `fl._recursiveMergeAndExpandIncludes`
@@ -472,6 +473,12 @@ Native lists are generally forbidden, except allowed paths/fields detected in co
 ## Tpl Delimiter Validation
 - `global.validation.validateTplDelimiters` controls `E_TPL_DELIMITERS`/`E_TPL_BRACES` checks in tpl-like strings
 - default behavior is backward-compatible (disabled unless enabled explicitly)
+
+## Value Reference Interpolation
+- `$fl.value{global.path}` is available in every string resolved through `fl.value`
+- paths are relative to `.Values`; embedded, multiple, env-aware and recursive references are supported
+- `$$fl.value{global.path}` escapes a literal marker; missing paths, invalid syntax and cycles fail explicitly
+- values without the marker keep existing behavior
 
 ## Library Entry Point
 - Consumer chart must call: `{{ include "apps-utils.init-library" $ }}`

--- a/docs/reference-values.md
+++ b/docs/reference-values.md
@@ -124,6 +124,38 @@ ports: |
 - по умолчанию выключен (`false`) для обратной совместимости с literal-контентом, где `{{ ... }}` — это данные (например dashboards/alerts/templates);
 - при включении ошибки рендера будут вида `E_TPL_DELIMITERS` / `E_TPL_BRACES`.
 
+<a id="param-value-references"></a>
+### Короткие ссылки `$fl.value{...}`
+
+Синтаксис доступен сразу во всех строках, которые библиотека обрабатывает через `fl.value`:
+
+```yaml
+global:
+  vars:
+    replicas: 3
+    registry: registry.example.com
+
+apps-stateless:
+  api:
+    replicas: '$fl.value{global.vars.replicas}'
+    containers:
+      main:
+        image:
+          name: '$fl.value{global.vars.registry}/api'
+          staticTag: "1.0"
+```
+
+Контракт:
+- путь задаётся относительно `.Values`; разрешены dot-сегменты `[A-Za-z0-9_-]+`;
+- поддерживаются несколько ссылок, ссылки внутри текста и рекурсивные ссылки;
+- целевое значение проходит обычное env-разрешение `fl.value` (exact -> regex -> `_default`);
+- `$$fl.value{global.path}` выводит literal `$fl.value{global.path}`;
+- отсутствующий путь, неверный синтаксис и цикл дают `E_VALUE_REF_NOT_FOUND`, `E_VALUE_REF_SYNTAX` и `E_VALUE_REF_CYCLE`;
+- старые `{{ ... }}`-значения продолжают работать и могут сочетаться с новым синтаксисом;
+- поддержка централизована в `fl.value`, поэтому действует также через `fl.valueQuoted`, `fl.valueSingleQuoted` и `apps.value`; custom renderer, обходящий эти helpers, должен вызвать `fl.value` явно.
+
+Значения без нового маркера не меняют поведение. Если нужен literal `$fl.value{...}`, используйте escape `$$fl.value{...}`.
+
 ### 2.1 `global.deploy` + `global.releases`
 <a id="param-global-deploy"></a>
 <a id="param-global-releases"></a>

--- a/scripts/check-contracts.sh
+++ b/scripts/check-contracts.sh
@@ -856,6 +856,213 @@ YAML
 
 grep -q "\[helm-apps:E_TPL_DELIMITERS\]" /tmp/contracts_invalid_tpl_delimiters.err
 
+echo "==> Value reference interpolation checks"
+cat > /tmp/contracts_value_refs.yaml <<'YAML'
+global:
+  valueReferenceHelperContract: true
+  refs:
+    name: value-ref-config
+    text: alpha
+    number: 3
+    empty: ""
+    boolean: false
+    host: value-ref.example.com
+    segment-key:
+      under_score1: segment-value
+    byEnv:
+      _default: default-value
+      "^prod-.+$": regex-value
+      production: production-value
+    recursive: '$fl.value{global.refs.text}-recursive'
+    recursiveTwice: '$fl.value{global.refs.recursive}-twice'
+    template: '{{ $.Values.global.refs.text }}-template'
+apps-configmaps:
+  value-ref-contract:
+    enabled: true
+    name: '$fl.value{global.refs.name}'
+    data: |
+      direct: "$fl.value{global.refs.text}"
+      embedded: "pre-$fl.value{global.refs.text}-post"
+      repeated: "$fl.value{global.refs.text}:$fl.value{global.refs.text}"
+      multiple: "$fl.value{global.refs.text}-$fl.value{global.refs.byEnv}"
+      environment: "$fl.value{global.refs.byEnv}"
+      recursive: "$fl.value{global.refs.recursive}"
+      recursiveTwice: "$fl.value{global.refs.recursiveTwice}"
+      referencedTpl: "$fl.value{global.refs.template}"
+      escaped: "$$fl.value{global.refs.text}"
+      escapedMixed: "$$fl.value{global.refs.text}|$fl.value{global.refs.text}"
+      escapedMalformed: "$$fl.value{global.bad path}"
+      empty: "$fl.value{global.refs.empty}"
+      boolean: "$fl.value{global.refs.boolean}"
+      segmented: "$fl.value{global.refs.segment-key.under_score1}"
+      plain: "unchanged"
+      legacyTpl: "{{ $.Values.global.refs.text }}"
+      mixed: "$fl.value{global.refs.text}-{{ $.Values.global.refs.byEnv.production }}"
+apps-stateless:
+  value-ref-replicas:
+    enabled: true
+    name: value-ref-replicas
+    replicas: '$fl.value{global.refs.number}'
+    containers:
+      main:
+        image:
+          name: nginx
+          staticTag: "1.27"
+apps-ingresses:
+  value-ref-ingress:
+    enabled: true
+    name: value-ref-ingress
+    host: '$fl.value{global.refs.host}'
+    paths: |
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: value-ref-replicas
+            port:
+              number: 80
+YAML
+
+for env in production prod-east staging; do
+  helm template contracts tests/contracts \
+    --set "global.env=${env}" \
+    --values /tmp/contracts_value_refs.yaml \
+    > "/tmp/contracts_value_refs_${env}.out"
+done
+
+ruby - <<'RUBY'
+require 'yaml'
+
+resolved_by_env = {
+  'production' => 'production-value',
+  'prod-east' => 'regex-value',
+  'staging' => 'default-value'
+}
+common_data = {
+  'direct' => 'alpha',
+  'embedded' => 'pre-alpha-post',
+  'repeated' => 'alpha:alpha',
+  'recursive' => 'alpha-recursive',
+  'recursiveTwice' => 'alpha-recursive-twice',
+  'referencedTpl' => 'alpha-template',
+  'escaped' => '$fl.value{global.refs.text}',
+  'escapedMixed' => '$fl.value{global.refs.text}|alpha',
+  'escapedMalformed' => '$fl.value{global.bad path}',
+  'empty' => '',
+  'boolean' => 'false',
+  'segmented' => 'segment-value',
+  'plain' => 'unchanged',
+  'legacyTpl' => 'alpha',
+  'mixed' => 'alpha-production-value'
+}
+helper_data = {
+  'flValue' => 'alpha',
+  'flValueQuoted' => 'alpha',
+  'flValueSingleQuoted' => 'alpha',
+  'appsValue' => 'alpha'
+}
+
+resolved_by_env.each do |env, resolved|
+  docs = YAML.load_stream(File.read("/tmp/contracts_value_refs_#{env}.out")).compact
+  cm = docs.find { |doc| doc['kind'] == 'ConfigMap' && doc.dig('metadata', 'name') == 'value-ref-config' }
+  expected = common_data.merge(
+    'multiple' => "alpha-#{resolved}",
+    'environment' => resolved
+  )
+  abort "unexpected value reference data for #{env}: #{cm&.fetch('data', nil).inspect}" unless cm&.fetch('data', nil) == expected
+
+  helpers = docs.find { |doc| doc['kind'] == 'ConfigMap' && doc.dig('metadata', 'name') == 'value-reference-helpers' }
+  abort "value helper delegation failed for #{env}: #{helpers&.fetch('data', nil).inspect}" unless helpers&.fetch('data', nil) == helper_data
+
+  deployment = docs.find { |doc| doc['kind'] == 'Deployment' && doc.dig('metadata', 'name') == 'value-ref-replicas' }
+  abort "whole-value numeric reference failed for #{env}" unless deployment&.dig('spec', 'replicas') == 3
+
+  ingress = docs.find { |doc| doc['kind'] == 'Ingress' && doc.dig('metadata', 'name') == 'value-ref-ingress' }
+  abort "fl.valueQuoted reference failed for #{env}" unless ingress&.dig('spec', 'rules', 0, 'host') == 'value-ref.example.com'
+end
+RUBY
+
+assert_value_ref_error() {
+  local case_name="$1"
+  local error_code="$2"
+  local values_file="/tmp/contracts_value_ref_${case_name}.yaml"
+  local output_file="/tmp/contracts_value_ref_${case_name}.out"
+  local error_file="/tmp/contracts_value_ref_${case_name}.err"
+
+  if helm template contracts tests/contracts \
+    --set global.env=production \
+    --values "${values_file}" \
+    >"${output_file}" 2>"${error_file}"; then
+    echo "expected ${error_code} for value reference case ${case_name}"
+    exit 1
+  fi
+  grep -q "\\[helm-apps:${error_code}\\]" "${error_file}"
+}
+
+cat > /tmp/contracts_value_ref_missing.yaml <<'YAML'
+global:
+  refs:
+    text: alpha
+apps-configmaps:
+  value-ref-missing:
+    enabled: true
+    name: value-ref-missing
+    data: |
+      value: "$fl.value{global.refs.text.child}"
+YAML
+assert_value_ref_error missing E_VALUE_REF_NOT_FOUND
+grep -q "global.refs.text.child" /tmp/contracts_value_ref_missing.err
+
+cat > /tmp/contracts_value_ref_syntax.yaml <<'YAML'
+apps-configmaps:
+  value-ref-syntax:
+    enabled: true
+    name: value-ref-syntax
+    data: |
+      value: "$fl.value{global.bad path}"
+YAML
+assert_value_ref_error syntax E_VALUE_REF_SYNTAX
+
+cat > /tmp/contracts_value_ref_empty_segment.yaml <<'YAML'
+apps-configmaps:
+  value-ref-empty-segment:
+    enabled: true
+    name: value-ref-empty-segment
+    data: |
+      value: "$fl.value{global..text}"
+YAML
+assert_value_ref_error empty_segment E_VALUE_REF_SYNTAX
+
+cat > /tmp/contracts_value_ref_cycle.yaml <<'YAML'
+global:
+  refs:
+    first: '$fl.value{global.refs.second}'
+    second: '$fl.value{global.refs.first}'
+apps-configmaps:
+  value-ref-cycle:
+    enabled: true
+    name: value-ref-cycle
+    data: |
+      value: "$fl.value{global.refs.first}"
+YAML
+assert_value_ref_error cycle E_VALUE_REF_CYCLE
+grep -q "global.refs.first" /tmp/contracts_value_ref_cycle.err
+grep -q "global.refs.second" /tmp/contracts_value_ref_cycle.err
+
+cat > /tmp/contracts_value_ref_self_cycle.yaml <<'YAML'
+global:
+  refs:
+    self: '$fl.value{global.refs.self}'
+apps-configmaps:
+  value-ref-self-cycle:
+    enabled: true
+    name: value-ref-self-cycle
+    data: |
+      value: "$fl.value{global.refs.self}"
+YAML
+assert_value_ref_error self_cycle E_VALUE_REF_CYCLE
+
+
 echo "==> Internal-like release/deploy flow checks"
 helm template contracts tests/contracts \
   --set global.env=production \

--- a/scripts/generate-capabilities-prompt.sh
+++ b/scripts/generate-capabilities-prompt.sh
@@ -91,6 +91,12 @@ mkdir -p "$(dirname "$OUT")"
   printf -- '- `global.validation.validateTplDelimiters` controls `E_TPL_DELIMITERS`/`E_TPL_BRACES` checks in tpl-like strings\n'
   printf -- '- default behavior is backward-compatible (disabled unless enabled explicitly)\n\n'
 
+  printf '## Value Reference Interpolation\n'
+  printf -- '- `$fl.value{global.path}` is available in every string resolved through `fl.value`\n'
+  printf -- '- paths are relative to `.Values`; embedded, multiple, env-aware and recursive references are supported\n'
+  printf -- '- `$$fl.value{global.path}` escapes a literal marker; missing paths, invalid syntax and cycles fail explicitly\n'
+  printf -- '- values without the marker keep existing behavior\n\n'
+
   printf '## Library Entry Point\n'
   printf -- '- Consumer chart must call: `{{ include "apps-utils.init-library" $ }}`\n\n'
 

--- a/tests/.helm/values.yaml
+++ b/tests/.helm/values.yaml
@@ -28,6 +28,11 @@ global:
   # Default=false keeps backward compatibility; prefer apps-service-accounts.
   # validation:
   #   forbidLegacyServiceAccountClusterRole: true
+  # Short references are available in every string rendered through fl.value.
+  # vars:
+  #   replicas: 3
+  # Example: replicas: '$fl.value{global.vars.replicas}'
+  # Escape a literal marker as '$$fl.value{global.vars.replicas}'.
   # Opt-in validation for '{{'/'}}' balance in fl.value string templates.
   # Default=false keeps backward compatibility for literal template-like payloads (e.g. dashboards/alerts).
   # validation:

--- a/tests/contracts/templates/init-helm-apps-library.yaml
+++ b/tests/contracts/templates/init-helm-apps-library.yaml
@@ -1,1 +1,13 @@
 {{- include "apps-utils.init-library" $ }}
+{{ if .Values.global.valueReferenceHelperContract }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: value-reference-helpers
+data:
+  flValue: {{ include "fl.value" (list $ . "$fl.value{global.refs.text}") | quote }}
+  flValueQuoted: {{ include "fl.valueQuoted" (list $ . "$fl.value{global.refs.text}") }}
+  flValueSingleQuoted: {{ include "fl.valueSingleQuoted" (list $ . "$fl.value{global.refs.text}") }}
+  appsValue: {{ include "apps.value" (list $ . "$fl.value{global.refs.text}" "appsValue") | quote }}
+{{ end }}


### PR DESCRIPTION
## Summary

- add immediate `$fl.value{global.path}` interpolation through `fl.value`
- preserve existing `{{ ... }}` behavior and support explicit `$$fl.value{...}` escaping
- add exact, regex, default, recursive, helper-delegation, compatibility and failure contracts
- prepare feature release `1.9.0`

## Verification

- `bash scripts/check-contracts.sh`
- `werf helm lint tests/.helm --values tests/.helm/values.yaml`
- `helm template contracts tests/contracts --set global.env=production`
- compatibility renders for Kubernetes 1.29.0 and 1.20.15
